### PR TITLE
Validate Strategy and Property of Strategy

### DIFF
--- a/src/main/java/org/fit/ssapp/dto/request/GameTheoryProblemDto.java
+++ b/src/main/java/org/fit/ssapp/dto/request/GameTheoryProblemDto.java
@@ -3,6 +3,7 @@ package org.fit.ssapp.dto.request;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.fit.ssapp.dto.validator.ValidStrategyStructure;
 import org.fit.ssapp.ss.gt.Conflict;
 import org.fit.ssapp.ss.gt.NormalPlayer;
 import org.fit.ssapp.ss.gt.SpecialPlayer;
@@ -27,6 +28,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@ValidStrategyStructure
 public class GameTheoryProblemDto implements ProblemRequestDto {
   private SpecialPlayer specialPlayer;
 

--- a/src/main/java/org/fit/ssapp/dto/validator/StrategyStructureValidator.java
+++ b/src/main/java/org/fit/ssapp/dto/validator/StrategyStructureValidator.java
@@ -1,0 +1,69 @@
+package org.fit.ssapp.dto.validator;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.fit.ssapp.dto.request.GameTheoryProblemDto;
+import org.fit.ssapp.ss.gt.NormalPlayer;
+import org.fit.ssapp.ss.gt.Strategy;
+
+import java.util.List;
+
+public class StrategyStructureValidator implements ConstraintValidator<ValidStrategyStructure, GameTheoryProblemDto> {
+
+    @Override
+    public boolean isValid(GameTheoryProblemDto dto, ConstraintValidatorContext context) {
+        List<NormalPlayer> players = dto.getNormalPlayers();
+        if (players == null || players.size() < 2) return true; // nothing to compare
+
+        boolean isValid = true;
+
+        // Get the standard number of strategies from the first player
+        int expectedStrategyCount = players.get(0).getStrategies() != null
+                ? players.get(0).getStrategies().size()
+                : 0;
+
+        // Get the standard number of properties from the first strategy of the first player
+        int expectedPropertyCount = players.get(0).getStrategies() != null &&
+                !players.get(0).getStrategies().isEmpty() &&
+                players.get(0).getStrategies().get(0).getProperties() != null
+                ? players.get(0).getStrategies().get(0).getProperties().size()
+                : 0;
+
+        for (int i = 0; i < players.size(); i++) {
+            NormalPlayer player = players.get(i);
+            List<Strategy> strategies = player.getStrategies();
+
+            // Validate strategy count
+            if (strategies == null || strategies.size() != expectedStrategyCount) {
+                addViolation(context,
+                        String.format("normalPlayers[%d].strategies", i),
+                        String.format("Expected %d strategies but found %d",
+                                expectedStrategyCount, strategies == null ? 0 : strategies.size()));
+                isValid = false;
+                continue;
+            }
+
+            for (int j = 0; j < strategies.size(); j++) {
+                Strategy strategy = strategies.get(j);
+                List<Double> properties = strategy.getProperties();
+
+                if (properties == null || properties.size() != expectedPropertyCount) {
+                    addViolation(context,
+                            String.format("normalPlayers[%d].strategies[%d].properties", i, j),
+                            String.format("Expected %d properties but found %d",
+                                    expectedPropertyCount, properties == null ? 0 : properties.size()));
+                    isValid = false;
+                }
+            }
+        }
+
+        return isValid;
+    }
+
+    private void addViolation(ConstraintValidatorContext context, String field, String message) {
+        context.disableDefaultConstraintViolation();
+        context.buildConstraintViolationWithTemplate("• field: \"" + field + "\", message: \"" + message + "\"")
+                .addConstraintViolation();
+    }
+}
+

--- a/src/main/java/org/fit/ssapp/dto/validator/StrategyStructureValidator.java
+++ b/src/main/java/org/fit/ssapp/dto/validator/StrategyStructureValidator.java
@@ -83,10 +83,11 @@ public class StrategyStructureValidator implements ConstraintValidator<ValidStra
 
     private void addViolation(ConstraintValidatorContext context, String field, String message) {
         context.disableDefaultConstraintViolation();
-        context.buildConstraintViolationWithTemplate(
-                String.format("field: \"%s\", message: \"%s\"", field, message)
-        ).addConstraintViolation();
+        context.buildConstraintViolationWithTemplate(message)
+                .addPropertyNode(field)
+                .addConstraintViolation();
     }
+
 }
 
 

--- a/src/main/java/org/fit/ssapp/dto/validator/StrategyStructureValidator.java
+++ b/src/main/java/org/fit/ssapp/dto/validator/StrategyStructureValidator.java
@@ -13,16 +13,14 @@ public class StrategyStructureValidator implements ConstraintValidator<ValidStra
     @Override
     public boolean isValid(GameTheoryProblemDto dto, ConstraintValidatorContext context) {
         List<NormalPlayer> players = dto.getNormalPlayers();
-        if (players == null || players.size() < 2) return true; // nothing to compare
+        if (players == null || players.size() < 2) return true;
 
         boolean isValid = true;
 
-        // Get the standard number of strategies from the first player
         int expectedStrategyCount = players.get(0).getStrategies() != null
                 ? players.get(0).getStrategies().size()
                 : 0;
 
-        // Get the standard number of properties from the first strategy of the first player
         int expectedPropertyCount = players.get(0).getStrategies() != null &&
                 !players.get(0).getStrategies().isEmpty() &&
                 players.get(0).getStrategies().get(0).getProperties() != null
@@ -33,26 +31,28 @@ public class StrategyStructureValidator implements ConstraintValidator<ValidStra
             NormalPlayer player = players.get(i);
             List<Strategy> strategies = player.getStrategies();
 
-            // Validate strategy count
+            // Check strategy count
             if (strategies == null || strategies.size() != expectedStrategyCount) {
                 addViolation(context,
-                        String.format("normalPlayers[%d].strategies", i),
-                        String.format("Expected %d strategies but found %d",
-                                expectedStrategyCount, strategies == null ? 0 : strategies.size()));
+                        "normalPlayers.strategies",
+                        String.format("At player index %d, expected %d strategies but found %d",
+                                i, expectedStrategyCount, strategies == null ? 0 : strategies.size()));
                 isValid = false;
-                continue;
             }
 
-            for (int j = 0; j < strategies.size(); j++) {
-                Strategy strategy = strategies.get(j);
-                List<Double> properties = strategy.getProperties();
+            // Check property count inside each strategy (if strategies != null)
+            if (strategies != null) {
+                for (int j = 0; j < strategies.size(); j++) {
+                    Strategy strategy = strategies.get(j);
+                    List<Double> properties = strategy.getProperties();
 
-                if (properties == null || properties.size() != expectedPropertyCount) {
-                    addViolation(context,
-                            String.format("normalPlayers[%d].strategies[%d].properties", i, j),
-                            String.format("Expected %d properties but found %d",
-                                    expectedPropertyCount, properties == null ? 0 : properties.size()));
-                    isValid = false;
+                    if (properties == null || properties.size() != expectedPropertyCount) {
+                        addViolation(context,
+                                "normalPlayers.strategies.properties",
+                                String.format("At player index %d, strategy index %d, expected %d properties but found %d",
+                                        i, j, expectedPropertyCount, properties == null ? 0 : properties.size()));
+                        isValid = false;
+                    }
                 }
             }
         }
@@ -62,8 +62,11 @@ public class StrategyStructureValidator implements ConstraintValidator<ValidStra
 
     private void addViolation(ConstraintValidatorContext context, String field, String message) {
         context.disableDefaultConstraintViolation();
-        context.buildConstraintViolationWithTemplate("• field: \"" + field + "\", message: \"" + message + "\"")
-                .addConstraintViolation();
+        context.buildConstraintViolationWithTemplate(
+                String.format("• field: \"%s\", message: \"%s\"", field, message)
+        ).addConstraintViolation();
     }
 }
+
+
 

--- a/src/main/java/org/fit/ssapp/dto/validator/ValidStrategyStructure.java
+++ b/src/main/java/org/fit/ssapp/dto/validator/ValidStrategyStructure.java
@@ -1,0 +1,19 @@
+package org.fit.ssapp.dto.validator;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = StrategyStructureValidator.class)
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidStrategyStructure {
+    String message() default "Strategies and properties must be consistent across all normal players";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}
+


### PR DESCRIPTION
### Validate số lượng strategy và property của strategy của các NormalPlayer

**Các trường hợp vi phạm**
1. Số lượng strategy giữa các NormalPlayer không đồng nhất

- Mỗi player phải có cùng số lượng strategy
- Nếu một player có nhiều hơn/ít hơn so với player đầu tiên → vi phạm

2. Số lượng property trong từng strategy không đồng nhất

- Các strategy tại cùng index giữa các player phải có cùng số lượng property
- Nếu khác nhau → vi phạm

3. Giá trị không phải số (non-numeric)

- Không áp dụng trong task này vì không xử lý giá trị của property, chỉ kiểm tra kích thước

Ví dụ
**Request**

```
{
  "normalPlayers": [
    {
      "name": "P1",
      "strategies": [
        { "name": "s1", "properties": [1.0, 2.0] },
        { "name": "s2", "properties": [3.0, 4.0] }
      ]
    },
    {
      "name": "P2",
      "strategies": [
        { "name": "s1", "properties": [1.0] }
      ]
    }
  ],
  "fitnessFunction": "someFunc",
  "defaultPayoffFunction": "somePayoff",
  "algorithm": "gt",
  "maxTime": 100,
  "generation": 10,
  "populationSize": 50
}
```


**Response**
```
{
  "message": "Validation failed",
  "details": [
    {
      "field": "normalPlayers[1].strategies",
      "message": "Expected 2 strategies but found 1"
    },
    {
      "field": "normalPlayers[1].strategies[0].properties",
      "message": "Expected 2 properties but found 1"
    }
  ]
}
```