### PR TITLE
Debug SMTUnitFitnessTest::testFitnessCustom #1: Update TwoSetFitnessEvaluator

### DIFF
--- a/src/main/java/org/fit/ssapp/ss/smt/evaluator/impl/TwoSetFitnessEvaluator.java
+++ b/src/main/java/org/fit/ssapp/ss/smt/evaluator/impl/TwoSetFitnessEvaluator.java
@@ -223,16 +223,16 @@ public class TwoSetFitnessEvaluator implements FitnessEvaluator {
    * Extracts satisfaction values for a specific set
    */
   private double[] getSatisfactoryOfASetByDefault(double[] satisfactions, int set) {
-    // Sử dụng Math.min(matchingData.getSize(), satisfactions.length) để tránh out of bounds.
-    int length = Math.min(matchingData.getSize(), satisfactions.length);
     List<Double> result = new ArrayList<>();
+    int[] sets = matchingData.getSets();
 
-    for (int i = 0; i < length; i++) {
-      result.add(satisfactions[i]);
+    for (int i = 0; i < satisfactions.length; i++) {
+      if (sets[i] == set) {
+        result.add(satisfactions[i]);
+      }
     }
 
     double[] temp = new double[result.size()];
-
     for (int i = 0; i < result.size(); i++) {
       temp[i] = result.get(i);
     }

--- a/src/main/java/org/fit/ssapp/ss/smt/evaluator/impl/TwoSetFitnessEvaluator.java
+++ b/src/main/java/org/fit/ssapp/ss/smt/evaluator/impl/TwoSetFitnessEvaluator.java
@@ -223,9 +223,11 @@ public class TwoSetFitnessEvaluator implements FitnessEvaluator {
    * Extracts satisfaction values for a specific set
    */
   private double[] getSatisfactoryOfASetByDefault(double[] satisfactions, int set) {
+    // Sử dụng Math.min(matchingData.getSize(), satisfactions.length) để tránh out of bounds.
+    int length = Math.min(matchingData.getSize(), satisfactions.length);
     List<Double> result = new ArrayList<>();
 
-    for (int i = 0; i < matchingData.getSize(); i++) {
+    for (int i = 0; i < length; i++) {
       result.add(satisfactions[i]);
     }
 
@@ -237,6 +239,7 @@ public class TwoSetFitnessEvaluator implements FitnessEvaluator {
 
     return temp;
   }
+
 
   /**
    * Converts double to String without scientific notation


### PR DESCRIPTION
## Debug SMTUnitFitnessTest::testFitnessCustom 

Lỗi xảy ra cho bài toán SMT chỉ khi sử dụng hàm custom `SIGMA{S_i}`.

Ví dụ, khi chạy test với những hàm sau:

```java
@CsvSource({
      "SIGMA{S1}, 12.0",
      "M1 + M2, 7.0",
      "SIGMA{S1} - M1, 9.0",
      "ceil(sqrt(SIGMA{S1})) + 2, 6",
      "ceil(SIGMA{S1} / 4), 3.0"
  })
```

Thì có duy nhất hàm `M1 + M2, 7.0` (Hàm mà không chứa `SIGMA{S1}`) là test passed.

## Lý do 

Một số lý do có thể kể đến như: 

matchingData.getSize() (số lượng entity thực tế) và satisfactions.length (số lượng satisfaction thực có thể khác nhau) - Trong bài toán ta đang giả định rằng hai cái này bằng nhau, dẫn đến có thể bị như thế này: `java.lang.ArrayIndexOutOfBoundsException: Index 3 out of bounds for length 3`

## Giải pháp 

### Chọn min từ hai array để tránh bị `java.lang.ArrayIndexOutOfBoundsException`. Trong hàm `getSatisfactoryOfASetByDefault()` thì ta thêm dòng này vào đầu.

```java
int length = Math.min(matchingData.getSize(), satisfactions.length);
```

Trong `getSatisfactoryOfASetByDefault()` thì nó sẽ chọn `length` như thế này:

```java
// Lặp dựa trên kích cỡ của `matchingData`, `matchingData` có thể lớn hơn `satisfaction` và dẫn đến lỗi.
for (int i = 0; i < matchingData.getSize(); i++) {
   result.add(satisfactions[i]);
}

double[] temp = new double[result.size()];

for (int i = 0; i < result.size()) {
   ...
}

...
```

### Giải pháp lâu dài

Viết thêm Validator để xác nhận độ dài của `satisfactions` với `matchingData.getSize()` (Nếu `satisfactions` nhỏ hơn `matchingData.getSize()` thì lỗi)